### PR TITLE
SK-1646 fixed code cov reports upload issue

### DIFF
--- a/.github/workflows/main_coverage_upload.yml
+++ b/.github/workflows/main_coverage_upload.yml
@@ -27,6 +27,8 @@ jobs:
         run: xcodebuild clean -workspace .swiftpm/xcode/package.xcworkspace -scheme Skyflow -enableCodeCoverage YES -destination "platform=iOS Simulator,OS=16.4,name=iPhone 14" VAULT_URL="${{ secrets.VAULT_URL }}" CAVV_TEST_TOKEN="${{ secrets.CAVV_TEST_TOKEN }}" PULL_FUNDS_INTEGRATION_CONNECTION_URL="${{ secrets.PULL_FUNDS_INTEGRATION_CONNECTION_URL }}" CVV_INTEGRATION_PATH="${{ secrets.CVV_INTEGRATION_PATH }}" CVV_INTEGRATION_CONNECTION_URL="${{ secrets.CVV_INTEGRATION_CONNECTION_URL }}" CONNECTION_URL="${{ secrets.CONNECTION_URL }}" TEST_EXPIRATION_DATE_TOKEN="${{ secrets.TEST_EXPIRATION_DATE_TOKEN }}" TEST_CARD_NUMBER="${{ secrets.TEST_CARD_NUMBER }}" TEST_SKYFLOW_ID1="${{ secrets.TEST_SKYFLOW_ID1 }}" TEST_SKYFLOW_ID2="${{ secrets.TEST_SKYFLOW_ID2 }}" TEST_SKYFLOW_ID3="${{ secrets.TEST_SKYFLOW_ID3 }}" TEST_SKYFLOW_ID4="${{ secrets.TEST_SKYFLOW_ID4 }}" DETOKENIZE_TEST_TOKEN="${{ secrets.DETOKENIZE_TEST_TOKEN }}" DETOKENIZE_TEST_VALUE="${{ secrets.DETOKENIZE_TEST_VALUE }}" TOKEN_ENDPOINT="${{ secrets.TOKEN_ENDPOINT }}" PULL_FUNDS_INTEGRATION_ID="${{ secrets.PULL_FUNDS_INTEGRATION_ID }}" VISA_BASIC_AUTH="${{ secrets.VISA_BASIC_AUTH }}" CVV_INTEGRATION_ID="${{ secrets.CVV_INTEGRATION_ID }}" VAULT_ID="${{ secrets.VAULT_ID }}" -quiet test
         
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,6 +47,9 @@ jobs:
         run: xcodebuild clean -workspace .swiftpm/xcode/package.xcworkspace -scheme Skyflow -enableCodeCoverage YES -destination "platform=iOS Simulator,OS=16.4,name=iPhone 14" VAULT_URL="${{ secrets.VAULT_URL }}" CAVV_TEST_TOKEN="${{ secrets.CAVV_TEST_TOKEN }}" PULL_FUNDS_INTEGRATION_CONNECTION_URL="${{ secrets.PULL_FUNDS_INTEGRATION_CONNECTION_URL }}" CVV_INTEGRATION_PATH="${{ secrets.CVV_INTEGRATION_PATH }}" CVV_INTEGRATION_CONNECTION_URL="${{ secrets.CVV_INTEGRATION_CONNECTION_URL }}" CONNECTION_URL="${{ secrets.CONNECTION_URL }}" TEST_EXPIRATION_DATE_TOKEN="${{ secrets.TEST_EXPIRATION_DATE_TOKEN }}" TEST_CARD_NUMBER="${{ secrets.TEST_CARD_NUMBER }}" TEST_SKYFLOW_ID1="${{ secrets.TEST_SKYFLOW_ID1 }}" TEST_SKYFLOW_ID2="${{ secrets.TEST_SKYFLOW_ID2 }}" TEST_SKYFLOW_ID3="${{ secrets.TEST_SKYFLOW_ID3 }}" TEST_SKYFLOW_ID4="${{ secrets.TEST_SKYFLOW_ID4 }}" DETOKENIZE_TEST_TOKEN="${{ secrets.DETOKENIZE_TEST_TOKEN }}" DETOKENIZE_TEST_VALUE="${{ secrets.DETOKENIZE_TEST_VALUE }}" TOKEN_ENDPOINT="${{ secrets.TOKEN_ENDPOINT }}" PULL_FUNDS_INTEGRATION_ID="${{ secrets.PULL_FUNDS_INTEGRATION_ID }}" VISA_BASIC_AUTH="${{ secrets.VISA_BASIC_AUTH }}" CVV_INTEGRATION_ID="${{ secrets.CVV_INTEGRATION_ID }}" VAULT_ID="${{ secrets.VAULT_ID }}" -quiet test        
         
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
 
 


### PR DESCRIPTION
## why:
Code coverage reports are not uploading on codecov, getting this error
`Unusable report due to issues such as source code unavailability, path mismatch, empty report, or incorrect data format. Please visit our troubleshooting document for assistance.`

#### Goal/Outcome: 
reports should be uploaded successfully and codecov should come in PR or main branch run 