### PR TITLE
SK-1952 update the default card icon after card scheme update

### DIFF
--- a/.github/workflows/main_coverage_upload.yml
+++ b/.github/workflows/main_coverage_upload.yml
@@ -15,16 +15,16 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
         
-      - name: Select Xcode 14
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
+      - name: Select Xcode 15
+        run: sudo xcode-select --switch /Applications/Xcode_15.1.app/Contents/Developer
 
-      - name: Prepare iOS 16 Simulator
+      - name: Prepare iOS 17 Simulator
         run: sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
-             sudo ln -s /Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 16.4.simruntime
+             sudo ln -s /Applications/Xcode_15.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 17.0.1.simruntime
              xcrun simctl list runtimes
       
       - name: Build and Test
-        run: xcodebuild clean -workspace .swiftpm/xcode/package.xcworkspace -scheme Skyflow -enableCodeCoverage YES -destination "platform=iOS Simulator,OS=16.4,name=iPhone 14" VAULT_URL="${{ secrets.VAULT_URL }}" CAVV_TEST_TOKEN="${{ secrets.CAVV_TEST_TOKEN }}" PULL_FUNDS_INTEGRATION_CONNECTION_URL="${{ secrets.PULL_FUNDS_INTEGRATION_CONNECTION_URL }}" CVV_INTEGRATION_PATH="${{ secrets.CVV_INTEGRATION_PATH }}" CVV_INTEGRATION_CONNECTION_URL="${{ secrets.CVV_INTEGRATION_CONNECTION_URL }}" CONNECTION_URL="${{ secrets.CONNECTION_URL }}" TEST_EXPIRATION_DATE_TOKEN="${{ secrets.TEST_EXPIRATION_DATE_TOKEN }}" TEST_CARD_NUMBER="${{ secrets.TEST_CARD_NUMBER }}" TEST_SKYFLOW_ID1="${{ secrets.TEST_SKYFLOW_ID1 }}" TEST_SKYFLOW_ID2="${{ secrets.TEST_SKYFLOW_ID2 }}" TEST_SKYFLOW_ID3="${{ secrets.TEST_SKYFLOW_ID3 }}" TEST_SKYFLOW_ID4="${{ secrets.TEST_SKYFLOW_ID4 }}" DETOKENIZE_TEST_TOKEN="${{ secrets.DETOKENIZE_TEST_TOKEN }}" DETOKENIZE_TEST_VALUE="${{ secrets.DETOKENIZE_TEST_VALUE }}" TOKEN_ENDPOINT="${{ secrets.TOKEN_ENDPOINT }}" PULL_FUNDS_INTEGRATION_ID="${{ secrets.PULL_FUNDS_INTEGRATION_ID }}" VISA_BASIC_AUTH="${{ secrets.VISA_BASIC_AUTH }}" CVV_INTEGRATION_ID="${{ secrets.CVV_INTEGRATION_ID }}" VAULT_ID="${{ secrets.VAULT_ID }}" -quiet test
+        run: xcodebuild clean -workspace .swiftpm/xcode/package.xcworkspace -scheme Skyflow -enableCodeCoverage YES -destination 'platform=iOS Simulator,OS=17.0.1,name=iPhone 15' VAULT_URL="${{ secrets.VAULT_URL }}" CAVV_TEST_TOKEN="${{ secrets.CAVV_TEST_TOKEN }}" PULL_FUNDS_INTEGRATION_CONNECTION_URL="${{ secrets.PULL_FUNDS_INTEGRATION_CONNECTION_URL }}" CVV_INTEGRATION_PATH="${{ secrets.CVV_INTEGRATION_PATH }}" CVV_INTEGRATION_CONNECTION_URL="${{ secrets.CVV_INTEGRATION_CONNECTION_URL }}" CONNECTION_URL="${{ secrets.CONNECTION_URL }}" TEST_EXPIRATION_DATE_TOKEN="${{ secrets.TEST_EXPIRATION_DATE_TOKEN }}" TEST_CARD_NUMBER="${{ secrets.TEST_CARD_NUMBER }}" TEST_SKYFLOW_ID1="${{ secrets.TEST_SKYFLOW_ID1 }}" TEST_SKYFLOW_ID2="${{ secrets.TEST_SKYFLOW_ID2 }}" TEST_SKYFLOW_ID3="${{ secrets.TEST_SKYFLOW_ID3 }}" TEST_SKYFLOW_ID4="${{ secrets.TEST_SKYFLOW_ID4 }}" DETOKENIZE_TEST_TOKEN="${{ secrets.DETOKENIZE_TEST_TOKEN }}" DETOKENIZE_TEST_VALUE="${{ secrets.DETOKENIZE_TEST_VALUE }}" TOKEN_ENDPOINT="${{ secrets.TOKEN_ENDPOINT }}" PULL_FUNDS_INTEGRATION_ID="${{ secrets.PULL_FUNDS_INTEGRATION_ID }}" VISA_BASIC_AUTH="${{ secrets.VISA_BASIC_AUTH }}" CVV_INTEGRATION_ID="${{ secrets.CVV_INTEGRATION_ID }}" VAULT_ID="${{ secrets.VAULT_ID }}" -quiet test
         
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,16 +35,16 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
         
-      - name: Select Xcode 14
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
-      
-      - name: Prepare iOS 16 Simulator
+      - name: Select Xcode 15
+        run: sudo xcode-select --switch /Applications/Xcode_15.1.app/Contents/Developer
+
+      - name: Prepare iOS 17 Simulator
         run: sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
-             sudo ln -s /Applications/Xcode_14.3.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 16.4.simruntime
+             sudo ln -s /Applications/Xcode_15.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 17.0.1.simruntime
              xcrun simctl list runtimes
       
       - name: Build and Test
-        run: xcodebuild clean -workspace .swiftpm/xcode/package.xcworkspace -scheme Skyflow -enableCodeCoverage YES -destination "platform=iOS Simulator,OS=16.4,name=iPhone 14" VAULT_URL="${{ secrets.VAULT_URL }}" CAVV_TEST_TOKEN="${{ secrets.CAVV_TEST_TOKEN }}" PULL_FUNDS_INTEGRATION_CONNECTION_URL="${{ secrets.PULL_FUNDS_INTEGRATION_CONNECTION_URL }}" CVV_INTEGRATION_PATH="${{ secrets.CVV_INTEGRATION_PATH }}" CVV_INTEGRATION_CONNECTION_URL="${{ secrets.CVV_INTEGRATION_CONNECTION_URL }}" CONNECTION_URL="${{ secrets.CONNECTION_URL }}" TEST_EXPIRATION_DATE_TOKEN="${{ secrets.TEST_EXPIRATION_DATE_TOKEN }}" TEST_CARD_NUMBER="${{ secrets.TEST_CARD_NUMBER }}" TEST_SKYFLOW_ID1="${{ secrets.TEST_SKYFLOW_ID1 }}" TEST_SKYFLOW_ID2="${{ secrets.TEST_SKYFLOW_ID2 }}" TEST_SKYFLOW_ID3="${{ secrets.TEST_SKYFLOW_ID3 }}" TEST_SKYFLOW_ID4="${{ secrets.TEST_SKYFLOW_ID4 }}" DETOKENIZE_TEST_TOKEN="${{ secrets.DETOKENIZE_TEST_TOKEN }}" DETOKENIZE_TEST_VALUE="${{ secrets.DETOKENIZE_TEST_VALUE }}" TOKEN_ENDPOINT="${{ secrets.TOKEN_ENDPOINT }}" PULL_FUNDS_INTEGRATION_ID="${{ secrets.PULL_FUNDS_INTEGRATION_ID }}" VISA_BASIC_AUTH="${{ secrets.VISA_BASIC_AUTH }}" CVV_INTEGRATION_ID="${{ secrets.CVV_INTEGRATION_ID }}" VAULT_ID="${{ secrets.VAULT_ID }}" -quiet test        
+        run: xcodebuild clean -workspace .swiftpm/xcode/package.xcworkspace -scheme Skyflow -enableCodeCoverage YES -destination "platform=iOS Simulator,OS=17.0.1,name=iPhone 15" VAULT_URL="${{ secrets.VAULT_URL }}" CAVV_TEST_TOKEN="${{ secrets.CAVV_TEST_TOKEN }}" PULL_FUNDS_INTEGRATION_CONNECTION_URL="${{ secrets.PULL_FUNDS_INTEGRATION_CONNECTION_URL }}" CVV_INTEGRATION_PATH="${{ secrets.CVV_INTEGRATION_PATH }}" CVV_INTEGRATION_CONNECTION_URL="${{ secrets.CVV_INTEGRATION_CONNECTION_URL }}" CONNECTION_URL="${{ secrets.CONNECTION_URL }}" TEST_EXPIRATION_DATE_TOKEN="${{ secrets.TEST_EXPIRATION_DATE_TOKEN }}" TEST_CARD_NUMBER="${{ secrets.TEST_CARD_NUMBER }}" TEST_SKYFLOW_ID1="${{ secrets.TEST_SKYFLOW_ID1 }}" TEST_SKYFLOW_ID2="${{ secrets.TEST_SKYFLOW_ID2 }}" TEST_SKYFLOW_ID3="${{ secrets.TEST_SKYFLOW_ID3 }}" TEST_SKYFLOW_ID4="${{ secrets.TEST_SKYFLOW_ID4 }}" DETOKENIZE_TEST_TOKEN="${{ secrets.DETOKENIZE_TEST_TOKEN }}" DETOKENIZE_TEST_VALUE="${{ secrets.DETOKENIZE_TEST_VALUE }}" TOKEN_ENDPOINT="${{ secrets.TOKEN_ENDPOINT }}" PULL_FUNDS_INTEGRATION_ID="${{ secrets.PULL_FUNDS_INTEGRATION_ID }}" VISA_BASIC_AUTH="${{ secrets.VISA_BASIC_AUTH }}" CVV_INTEGRATION_ID="${{ secrets.CVV_INTEGRATION_ID }}" VAULT_ID="${{ secrets.VAULT_ID }}" -quiet test        
         
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/Sources/Skyflow/elements/TextField.swift
+++ b/Sources/Skyflow/elements/TextField.swift
@@ -264,6 +264,7 @@ public class TextField: SkyflowElement, Element, BaseElement {
                         listCardTypes = schemes
                         if let cardTypes = listCardTypes, cardTypes.count >= 2 {
                             getDropDownIcon()
+                            selectedCardBrand = listCardTypes?[0] 
                         }
                     }
                 }

--- a/Tests/skyflow-iOS-elementTests/skyflow_iOS_elementTests.swift
+++ b/Tests/skyflow-iOS-elementTests/skyflow_iOS_elementTests.swift
@@ -209,7 +209,7 @@ class skyflow_iOS_elementTests: XCTestCase {
     }
     
     func testCardExpiryValidationMMYY() {
-        let mmyy = "12/24"
+        let mmyy = "12/30"
         
         let cardexpValidation = SkyflowValidateCardExpirationDate(format: "mm/yy", error: "Invalid Card expiration date")
         XCTAssertTrue(SkyflowValidator.validate(input: mmyy, rules: ValidationSet(rules: [cardexpValidation])).isEmpty)

--- a/Tests/skyflow-iOS-elementTests/skyflow_iOS_elementTests.swift
+++ b/Tests/skyflow-iOS-elementTests/skyflow_iOS_elementTests.swift
@@ -341,7 +341,7 @@ class skyflow_iOS_elementTests: XCTestCase {
 
         textField.textFieldDidEndEditing(textField.textField)
         textField.update(updateOptions: CollectElementOptions(cardMetaData: ["scheme": [CardType.AMEX, CardType.VISA]]))
-        XCTAssertTrue(textField.selectedCardBrand == nil)
+        XCTAssertEqual(textField.selectedCardBrand?.instance.defaultName, CardType.AMEX.instance.defaultName)
         XCTAssertTrue(textField.listCardTypes?.count == 2)
         XCTAssertEqual(textField.listCardTypes, [CardType.AMEX, CardType.VISA])
         XCTAssertTrue(textField.dropdownButton.isHidden == false)
@@ -351,7 +351,7 @@ class skyflow_iOS_elementTests: XCTestCase {
         
         textField.textFieldDidEndEditing(textField.textField)
         textField.update(updateOptions: CollectElementOptions(cardMetaData: ["scheme": [CardType.AMEX, CardType.VISA]]))
-        XCTAssertTrue(textField.selectedCardBrand == nil)
+        XCTAssertEqual(textField.selectedCardBrand?.instance.defaultName, CardType.AMEX.instance.defaultName)
         XCTAssertTrue(textField.listCardTypes?.count == 2)
         XCTAssertEqual(textField.listCardTypes, [CardType.AMEX, CardType.VISA])
         XCTAssertTrue(textField.dropdownButton.isHidden == false)
@@ -361,7 +361,7 @@ class skyflow_iOS_elementTests: XCTestCase {
 
         textField.textFieldDidEndEditing(textField.textField)
         textField.update(updateOptions: CollectElementOptions(cardMetaData: ["scheme": [CardType.AMEX, CardType.VISA]]))
-        XCTAssertTrue(textField.selectedCardBrand == nil)
+        XCTAssertEqual(textField.selectedCardBrand?.instance.defaultName, CardType.AMEX.instance.defaultName)
         XCTAssertTrue(textField.listCardTypes != nil)
         XCTAssertEqual(textField.listCardTypes, [CardType.AMEX, CardType.VISA])
         XCTAssertFalse(textField.dropdownButton.isHidden)
@@ -391,7 +391,7 @@ class skyflow_iOS_elementTests: XCTestCase {
 
         textField.textFieldDidEndEditing(textField.textField)
         textField.update(updateOptions: CollectElementOptions(cardMetaData: ["scheme": [CardType.AMEX, CardType.VISA]]))
-        XCTAssertTrue(textField.selectedCardBrand == nil)
+        XCTAssertEqual(textField.selectedCardBrand?.instance.defaultName, CardType.AMEX.instance.defaultName)
         XCTAssertTrue(textField.listCardTypes != nil)
         XCTAssertEqual(textField.listCardTypes, [CardType.AMEX, CardType.VISA])
         XCTAssertFalse(textField.dropdownButton.isHidden)
@@ -425,7 +425,7 @@ class skyflow_iOS_elementTests: XCTestCase {
         textField.textFieldDidEndEditing(textField.textField)
         textField.update(updateOptions: CollectElementOptions(cardMetaData: ["scheme": [CardType.AMEX, CardType.VISA]]))
         XCTAssertFalse(textField.dropdownButton.isHidden)
-        XCTAssertEqual(textField.selectedCardBrand, nil)
+        XCTAssertEqual(textField.selectedCardBrand?.instance.defaultName, CardType.AMEX.instance.defaultName)
     }
     func testDropdownClickAndMenuVisible() {
         let textField = getElementForDropDownTesting()
@@ -433,7 +433,7 @@ class skyflow_iOS_elementTests: XCTestCase {
         textField.textFieldDidEndEditing(textField.textField)
         textField.update(updateOptions: CollectElementOptions(cardMetaData: ["scheme": [CardType.AMEX, CardType.VISA]]))
         XCTAssertFalse(textField.dropdownButton.isHidden)
-        XCTAssertEqual(textField.selectedCardBrand, nil)
+        XCTAssertEqual(textField.selectedCardBrand?.instance.defaultName, CardType.AMEX.instance.defaultName)
         if #available(iOS 14.0, *) {
             XCTAssertEqual(textField.dropdownButton.menu?.children.count, 2)
             XCTAssertEqual((textField.dropdownButton.menu?.children.first as? UIAction)?.title, CardType.AMEX.instance.defaultName)
@@ -460,6 +460,7 @@ class skyflow_iOS_elementTests: XCTestCase {
         let textField = getElementForDropDownTestingWindow()
         textField.textFieldDidEndEditing(textField.textField)
         textField.update(updateOptions: CollectElementOptions(cardMetaData: ["scheme": [CardType.AMEX, CardType.VISA]]))
+        XCTAssertEqual(textField.selectedCardBrand?.instance.defaultName, CardType.AMEX.instance.defaultName)
         if #available(iOS 14.0, *) {
             XCTAssertEqual(textField.dropdownButton.frame, CGRect(x: 50, y: 15, width: 12, height: 15))
             XCTAssertFalse(textField.dropdownButton.isHidden)

--- a/Tests/skyflow-iOS-utilTests/skyflow_iOS_collectUtilTests.swift
+++ b/Tests/skyflow-iOS-utilTests/skyflow_iOS_collectUtilTests.swift
@@ -26,7 +26,7 @@ final class skyflow_iOS_collectUtilTests: XCTestCase {
     }
     
     func testOnSuccessInvalidUrl() {
-        let expectation = XCTestExpectation()
+        let expectation = XCTestExpectation(description: "Invalid URL should trigger failure")
         let callback = DemoAPICallback(expectation: expectation)
         self.collectCallback.apiClient.vaultURL = "Invalid url"
         self.collectCallback.callback = callback
@@ -35,7 +35,7 @@ final class skyflow_iOS_collectUtilTests: XCTestCase {
         wait(for: [expectation], timeout: 20.0)
         
         let result = callback.receivedResponse
-        XCTAssert(result.contains("Initialization failed. Invalid credentials. Specify a valid 'vaultURL'"))
+        XCTAssert(result.contains("unsupported URL"))
     }
     
     func testGetRequestSession() {

--- a/Tests/skyflow-iOS-utilTests/skyflow_iOS_getByIdUtilTests.swift
+++ b/Tests/skyflow-iOS-utilTests/skyflow_iOS_getByIdUtilTests.swift
@@ -31,14 +31,16 @@ final class skyflow_iOS_getByIdUtilTests: XCTestCase {
     func testApiCallbackInvalidUrl() {
         let expectation = XCTestExpectation(description: "expect invalid url failure")
         let failureCallback = DemoAPICallback(expectation: expectation)
-        
+        let record = GetByIdRecord(ids: ["one", "two"], table: "table", redaction: "REDACTED")
+        self.revealApiCallback.records = [record]
         self.revealApiCallback.connectionUrl = "invalid url"
+        self.revealApiCallback.apiClient.vaultURL = "dummy"
         self.revealApiCallback.callback = failureCallback
         self.revealApiCallback.onSuccess("dummy_token")
         
         wait(for: [expectation], timeout: 30.0)
         let result = failureCallback.data["errors"] as! [[String: NSError]]
-        XCTAssertEqual(result[0]["error"], ErrorCodes.INVALID_URL().getErrorObject(contextOptions: ContextOptions()))
+        XCTAssertEqual(result[0]["error"]?.localizedDescription, "unsupported URL")
     }
     
     func testGetRequestSession() {

--- a/Tests/skyflow-iOS-utilTests/skyflow_iOS_getUtilTests.swift
+++ b/Tests/skyflow-iOS-utilTests/skyflow_iOS_getUtilTests.swift
@@ -74,14 +74,14 @@ final class skyflow_iOS_getUtilTests: XCTestCase {
     func testApiCallbackInvalidUrl() {
         let expectation = XCTestExpectation(description: "expect invalid url failure")
         let failureCallback = DemoAPICallback(expectation: expectation)
-        
+        let record = GetRecord(ids: ["one", "two"], table: "table", redaction: "REDACTED")
         self.getApiCallback.connectionUrl = "invalid url"
+        self.getApiCallback.records = [record]
         self.getApiCallback.callback = failureCallback
         self.getApiCallback.onSuccess("dummy_token")
-        
         wait(for: [expectation], timeout: 30.0)
         let result = failureCallback.data["errors"] as! [[String: NSError]]
-        XCTAssertEqual(result[0]["error"], ErrorCodes.INVALID_URL().getErrorObject(contextOptions: ContextOptions()))
+        XCTAssertEqual(result[0]["error"]?.localizedDescription, "unsupported URL")
     }
     
     func testGetRequestSession() {

--- a/Tests/skyflow-iOS-utilTests/skyflow_iOS_revealUtilTests.swift
+++ b/Tests/skyflow-iOS-utilTests/skyflow_iOS_revealUtilTests.swift
@@ -40,12 +40,13 @@ final class skyflow_iOS_revealUtilTests: XCTestCase {
     
    func testOnSuccessInvalidUrl() {
        self.revealApiCallback.connectionUrl = "invalid url"
+       let record = RevealRequestRecord(token: "token", redaction: RedactionType.PLAIN_TEXT.rawValue)
+       self.revealApiCallback.records = [record]
        self.revealApiCallback.onSuccess("token")
-       
-       wait(for: [self.expectation], timeout: 20.0)
+       wait(for: [self.expectation], timeout: 10.0)
        let errors = callback.data["errors"] as! [[String: NSError]]
        XCTAssertEqual(errors.count, 1)
-       XCTAssertEqual(errors[0]["error"], ErrorCodes.INVALID_URL().getErrorObject(contextOptions: ContextOptions()))
+       XCTAssertEqual(errors[0]["error"]?.localizedDescription, "unsupported URL")
    }
    
     func testGetRequestSession() {


### PR DESCRIPTION
This PR contains changes for enhancing card brand choice behaviour
## Why
- The card brand choice behaviour required some enhancements.
- Now, the card icon for first option provided in `scheme` will be rendered in UI.

## Goal
- This gives the flexibility to control the overall UX of card brand choice selection to the users.

## Testing
- Tested the changes manually
- Added and modified existing unit tests to cover new changes