### PR TITLE
SK-2977 add beta build disclaimer banner to README on release

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -9,8 +9,9 @@ on:
       - 'Skyflow.podspec'
       - '*.md'
       - 'Sources/Skyflow/Version.swift'
-    branches: 
+    branches:
       - public-release/*
+      - beta-release/*
 
 jobs:
   bump_version_spec:
@@ -30,6 +31,7 @@ jobs:
       run: |
         version=${{ steps.branch.outputs.branch }}
         version=${version#public-release/}
+        version=${version#beta-release/}
         echo "::set-output name=version::$version"
 
     - name: Bump Version
@@ -41,7 +43,8 @@ jobs:
       run: |
            git config user.name ${{ github.actor }}
            git config user.email ${{ github.actor }}@users.noreply.github.com
-           git add Skyflow.podspec 
+           git add Skyflow.podspec
            git add Sources/Skyflow/Version.swift
+           git add README.md
            git commit -m "[AUTOMATED] Public Release ${{ steps.version.outputs.version }}"
            git push origin

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -8,6 +8,7 @@ then
     sed -E "s/spec.version .+/spec.version      = \"$SEMVER\"/g" "./Skyflow.podspec" > tempfile
     sed -E "s/source .+/source       = { :git => \"https:\/\/github.com\/skyflowapi\/skyflow-iOS.git\", :tag => \"$1\" }/g" tempfile > ./Skyflow.podspec && rm -f tempfile
     sed -E "s/var SDK_VERSION = .+/var SDK_VERSION = \"$SEMVER\"/g" ./Sources/Skyflow/Version.swift > tempfile && cat tempfile > ./Sources/Skyflow/Version.swift && rm -f tempfile
+    ./scripts/toggle_beta_banner.sh README.md "$SEMVER"
 
 
     echo --------------------------

--- a/scripts/toggle_beta_banner.sh
+++ b/scripts/toggle_beta_banner.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Insert or remove the beta-release disclaimer banner in a README, based on
+# whether the given version string is a pre-release build.
+#
+# Usage: scripts/toggle_beta_banner.sh <readme-path> <version>
+#
+# Idempotent: safe to run repeatedly against the same file and version.
+set -euo pipefail
+
+readme_path="$1"
+version="$2"
+
+marker_start="<!-- SKYFLOW-BETA-DISCLAIMER:START -->"
+marker_end="<!-- SKYFLOW-BETA-DISCLAIMER:END -->"
+banner_body="> ⚠️ **Beta release — not for production use.** This is a pre-release build provided for early testing and feedback. It has not completed Skyflow's General Availability (GA) validation, its API may change before the stable release, and it is not covered by production SLAs or support commitments. Do not deploy beta builds to production environments."
+
+is_prerelease() {
+    [[ "$1" =~ -beta\.[0-9]+ ]]
+}
+
+# Strip any existing banner first, so re-running is idempotent regardless of
+# whether one is already present.
+awk -v start="$marker_start" -v end="$marker_end" '
+    { lines[NR] = $0 }
+    END {
+        start_line = 0
+        end_line = 0
+        for (i = 1; i <= NR; i++) {
+            if (lines[i] == start) start_line = i
+            if (lines[i] == end) end_line = i
+        }
+        if (start_line == 0 || end_line == 0) {
+            del_from = -1
+            del_to = -1
+        } else {
+            del_from = start_line
+            del_to = end_line
+            if (del_from > 1 && lines[del_from - 1] == "") del_from--
+            if (del_to < NR && lines[del_to + 1] == "") del_to++
+        }
+        for (i = 1; i <= NR; i++) {
+            if (i >= del_from && i <= del_to) continue
+            print lines[i]
+        }
+    }
+' "$readme_path" > "${readme_path}.tmp"
+mv "${readme_path}.tmp" "$readme_path"
+
+if is_prerelease "$version"; then
+    awk -v start="$marker_start" -v body="$banner_body" -v end="$marker_end" '
+        NR == 1 {
+            print
+            print ""
+            print start
+            print body
+            print end
+            print ""
+            next
+        }
+        { print }
+    ' "$readme_path" > "${readme_path}.tmp"
+    mv "${readme_path}.tmp" "$readme_path"
+fi

--- a/scripts/toggle_beta_banner.test.sh
+++ b/scripts/toggle_beta_banner.test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOGGLE="$SCRIPT_DIR/toggle_beta_banner.sh"
+FIXTURE="$(mktemp)"
+MARKER_START="<!-- SKYFLOW-BETA-DISCLAIMER:START -->"
+
+fail() {
+    echo "FAIL: $1"
+    rm -f "$FIXTURE"
+    exit 1
+}
+
+cat > "$FIXTURE" <<'EOF'
+# skyflow-iOS
+---
+Some intro text.
+EOF
+
+"$TOGGLE" "$FIXTURE" "1.26.0-beta.1"
+[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 1 ] || fail "banner not inserted for beta version"
+
+"$TOGGLE" "$FIXTURE" "1.26.0-beta.1"
+[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 1 ] || fail "banner duplicated on repeat run"
+
+"$TOGGLE" "$FIXTURE" "1.26.0"
+[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 0 ] || fail "banner not removed for GA version"
+
+grep -qF "Some intro text." "$FIXTURE" || fail "original README content lost"
+
+rm -f "$FIXTURE"
+echo "PASS: toggle_beta_banner.sh"


### PR DESCRIPTION
## Summary
Adds a standard beta/pre-release disclaimer banner to the README, automatically toggled in and out by the existing release automation — part of the CUST-4287 RCA follow-up ([SK-2977](https://skyflow.atlassian.net/browse/SK-2977)).

- `scripts/toggle_beta_banner.sh` inserts the banner right after the README's title when the version being released is a `-beta.N` pre-release, and removes it on GA releases. Idempotent.
- Wired into `scripts/bump_version.sh` (public/beta path only — internal/dev builds are unaffected).
- Also closes a real gap: `.github/workflows/bump_version.yml` only triggered on `public-release/*` branches — betas were bumped by hand with no CI help. It now also triggers on `beta-release/*` and strips either prefix when extracting the version, staging `README.md` alongside the podspec/version file.
- `scripts/toggle_beta_banner.test.sh` covers insertion, idempotency, GA removal, and content preservation.

This is one of 8 sibling PRs (android, iOS, js, node, python, react-js, react-native, java) rolling out the same disclaimer text and mechanism across the SDKs. skyflow-go is deferred to a follow-up (no release CI to hook into today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SK-2977]: https://skyflow.atlassian.net/browse/SK-2977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ