### PR TITLE
SK-2963: warn at startup when a beta/dev build targets a Production vault

### DIFF
--- a/Sources/Skyflow/core/Client.swift
+++ b/Sources/Skyflow/core/Client.swift
@@ -18,6 +18,9 @@ public class Client {
         self.vaultURL = skyflowConfig.vaultURL.hasSuffix("/") ? skyflowConfig.vaultURL + "v1/vaults/" : skyflowConfig.vaultURL + "/v1/vaults/"
         self.apiClient = APIClient(vaultID: skyflowConfig.vaultID, vaultURL: self.vaultURL, tokenProvider: skyflowConfig.tokenProvider)
         self.contextOptions = ContextOptions(logLevel: skyflowConfig.options!.logLevel, env: skyflowConfig.options!.env, interface: .CLIENT)
+        if isNonGaVersion(SDK_VERSION) && !isNonProdVaultUrl(self.vaultURL) {
+            Log.warn(message: .BETA_BUILD_WARNING, contextOptions: self.contextOptions)
+        }
         Log.info(message: .CLIENT_INITIALIZED, contextOptions: self.contextOptions)
     }
 

--- a/Sources/Skyflow/core/Message.swift
+++ b/Sources/Skyflow/core/Message.swift
@@ -50,6 +50,7 @@ internal enum Message {
     case FORMAT_AND_TRANSLATION
     case EMPTY_TRANSLATION_VALUE
     case VALIDATE_COMPOSABLE_RECORDS
+    case BETA_BUILD_WARNING
 
 
     var description: String {
@@ -93,6 +94,7 @@ internal enum Message {
         case .VALIDATE_GET_INPUT: return "Validating getByID input."
         case .FORMAT_AND_TRANSLATION: return "format or translation are not supported on <ELEMENT_TYPE> element type"
         case .EMPTY_TRANSLATION_VALUE: return "Value is empty in Translation Key"
+        case .BETA_BUILD_WARNING: return "This is a beta/pre-release build of the Skyflow SDK (v\(SDK_VERSION)). Beta builds are intended for acceptance testing only - you appear to be connecting to a Production vault. Contact your Skyflow representative before using this build in Production."
         }
     }
 

--- a/Sources/Skyflow/utils/BetaBuildDetection.swift
+++ b/Sources/Skyflow/utils/BetaBuildDetection.swift
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Skyflow
+*/
+
+// SK-2963: detection logic for the beta-build-in-prod startup warning.
+
+import Foundation
+
+// Beta/dev builds are published as <major>.<minor>.<patch>-beta.<n> or
+// -dev.<sha>; a plain public release has no suffix.
+internal func isNonGaVersion(_ version: String) -> Bool {
+    return version.range(of: "^\\d+\\.\\d+\\.\\d+$", options: .regularExpression) == nil
+}
+
+// options.env has no effect on which domain this SDK talks to (it's a decorative
+// DEV/PROD toggle only used to suppress a couple of setValue()/clearValue() warnings -
+// see TextField.swift/StateforText.swift), so it can't be trusted to tell us whether a
+// vault is Production. vaultURL is the one thing the customer sets that actually points
+// at their real vault - if it doesn't carry one of the non-prod domain markers, treat it
+// as pointed at Production, the same conservative "default to prod" every server SDK's
+// own Env-to-domain mapping uses.
+internal func isNonProdVaultUrl(_ vaultURL: String) -> Bool {
+    if vaultURL.isEmpty { return false }
+    return vaultURL.range(of: "(-preview|\\.dev|\\.tech)", options: .regularExpression) != nil
+}

--- a/Tests/skyflow-iOS-utilTests/skyflow_iOS_utilTests.swift
+++ b/Tests/skyflow-iOS-utilTests/skyflow_iOS_utilTests.swift
@@ -87,4 +87,63 @@ final class skyflow_iOS_utilTests: XCTestCase {
         XCTAssertEqual(records as NSDictionary, ["fields": ["name": "John Doe", "email": "john.doe@example.com"]])
         XCTAssertFalse(tokenization)
     }
+
+    // SK-2963: beta-build-in-prod warning
+
+    func testIsNonGaVersion_plainSemverIsGa() {
+        XCTAssertFalse(isNonGaVersion("1.25.1"))
+        XCTAssertFalse(isNonGaVersion("2.11.3"))
+    }
+
+    func testIsNonGaVersion_betaSuffixIsNonGa() {
+        XCTAssertTrue(isNonGaVersion("1.26.0-beta.1"))
+    }
+
+    func testIsNonGaVersion_devSuffixIsNonGa() {
+        XCTAssertTrue(isNonGaVersion("1.26.0-dev.abc1234"))
+    }
+
+    func testIsNonGaVersion_emptyOrGarbageIsNonGa() {
+        XCTAssertTrue(isNonGaVersion(""))
+        XCTAssertTrue(isNonGaVersion("not-a-version"))
+    }
+
+    func testIsNonProdVaultUrl_plainDomainLooksProd() {
+        XCTAssertFalse(isNonProdVaultUrl("https://abc123.vault.skyflowapis.com/v1/vaults/"))
+    }
+
+    func testIsNonProdVaultUrl_emptyLooksProd() {
+        XCTAssertFalse(isNonProdVaultUrl(""))
+    }
+
+    func testIsNonProdVaultUrl_previewDomainIsNonProd() {
+        XCTAssertTrue(isNonProdVaultUrl("https://abc123.vault.skyflowapis-preview.com/v1/vaults/"))
+    }
+
+    func testIsNonProdVaultUrl_devDomainIsNonProd() {
+        XCTAssertTrue(isNonProdVaultUrl("https://abc123.vault.skyflowapis.dev/v1/vaults/"))
+    }
+
+    func testIsNonProdVaultUrl_stageDomainIsNonProd() {
+        XCTAssertTrue(isNonProdVaultUrl("https://abc123.vault.skyflowapis.tech/v1/vaults/"))
+    }
+
+    // Confirms the wiring in Client.init doesn't crash under the "would warn" condition.
+    // SDK_VERSION is mutable (internal) module state, so this is the one place in this
+    // suite that can drive a genuinely non-GA version; it's restored in the defer so it
+    // doesn't leak into other tests that run in the same process.
+    func testClientInit_doesNotCrashForNonGaVersionAgainstProdLookingVaultUrl() {
+        let originalVersion = SDK_VERSION
+        SDK_VERSION = "99.0.0-beta.1"
+        defer { SDK_VERSION = originalVersion }
+
+        let config = Configuration(
+            vaultID: "vault_id",
+            vaultURL: "https://abc123.vault.skyflowapis.com",
+            tokenProvider: DemoTokenProvider(),
+            options: Options(logLevel: .WARN)
+        )
+        let client = Client(config)
+        XCTAssertEqual(client.vaultID, "vault_id")
+    }
 }


### PR DESCRIPTION
## Summary

Corrective action from the Fifth Third Bank RCA (CUST-4287): a beta/pre-release SDK build ended up running in a customer's Production environment undetected. This adds a startup warning so that doesn't happen silently again.

Adds a WARN-level log, emitted once in `Client.init()`, when:
- the SDK's own version (`SDK_VERSION`) is **non-GA** — any `-beta.N` or `-dev.<sha>` suffix, and
- the customer's **`vaultURL`** doesn't carry a recognized non-prod domain marker.

## Why `vaultURL`, not `options.env`

`options.env` (`Env.DEV`/`Env.PROD`) has no effect on which domain this SDK actually talks to here — it's a decorative toggle only used to suppress a couple of `setValue()`/`clearValue()` warnings. It can't be trusted to tell us whether a vault is Production. `vaultURL` is the one thing the customer actually sets that points at their real vault, so this checks that instead: if it doesn't contain `-preview`/`.dev`/`.tech`, treat it as pointed at Production — the same conservative "default to prod" every server SDK's own `Env`→domain mapping uses for an unset `env`.

## Changes

- `Sources/Skyflow/utils/BetaBuildDetection.swift` (new): `isNonGaVersion()` / `isNonProdVaultUrl()`, using the same `range(of:options:.regularExpression)` idiom `StringExtension.swift` already uses — this package targets `swift-tools-version 5.3`, which predates the native `Regex` type.
- `Sources/Skyflow/core/Message.swift`: new `BETA_BUILD_WARNING` case.
- `Sources/Skyflow/core/Client.swift`: wires the check into `init()`, right before the existing `CLIENT_INITIALIZED` log. Goes through `Log.warn`, so it respects the configured log level exactly like every other warning in this SDK (silent at the default `LogLevel.ERROR`).

## Testing

- `skyflow_iOS_utilTests.swift`: direct unit tests for both pure functions, plus a construction smoke test that temporarily mutates the internal, mutable `SDK_VERSION` global (the only way in this suite to drive a genuinely non-GA version, since it isn't build-injected) to confirm `Client.init` doesn't crash under the "would warn" condition.
- I deliberately did **not** add a stdout-capture assertion on the literal warning text — every `Log.*` call in this codebase goes straight to `print()` with no existing console-capture harness to extend, and introducing a new one I have no way to verify felt like the wrong tradeoff here. The condition logic itself (the part that actually decides whether to warn) is fully covered by the pure-function tests above.

**Verification caveat — please run the test suite in Xcode/CI on this PR before merging.** My sandbox is Linux with no Swift toolchain available, and Xcode itself is macOS-only — this is the one SDK in this cross-repo change that's categorically impossible to build or test outside Xcode/macOS, regardless of environment setup. I hand-verified the Swift for syntax, access levels (`@testable import` exposes the `internal` `isNonGaVersion`/`isNonProdVaultUrl`/`SDK_VERSION` used here), and consistency with this file's existing regex idiom, but none of it has actually compiled.

## Related

- Cross-SDK design + task tracking: SK-2963 (this is the reference-pattern implementation for skyflow-java; skyflow-android follows the same `vaultURL`-based shape in its own repo).
- SK-2977 owns the final public-facing message wording — the copy here is a placeholder pending that sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)